### PR TITLE
chore: bump node from v12 to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ branding:
   icon: "check-circle"
   color: "red"
 runs:
-  using: "node12"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
* Update github action.yml to point to node v20 latest LTS (https://nodejs.org/en/download/)