### PR TITLE
fix: add boolean default value for mark-complete

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ inputs:
   mark-complete:
     description: "Set to true if you would like to mark the Asana task as complete"
     required: false
+    default: false
 branding:
   icon: "check-circle"
   color: "red"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "github-asana-action",
-    "version": "v4.4.0",
+    "version": "v4.4.1",
     "description": "Action to integrate GitHub with Asana",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
`getBooleanInput` expects a default boolean value for a boolean input. It doesn't parse the empty string value as `false`, [it fails the parsing](https://github.com/actions/toolkit/pull/725/files#r975464665). 