### PR TITLE
fix(js): warn when no tickets are found in the PR body

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -98497,8 +98497,7 @@ try {
     core.info(`Task comment: "${TASK_COMMENT}"`);
     core.info(`Mark complete: "${MARK_COMPLETE}"`);
     core.info(`PR body: ${PULL_REQUEST.body}`);
-    let taskComment = null,
-        parseAsanaURL = null;
+    let taskComment = null
 
     if (!ASANA_PAT) {
         throw { message: "Asana PAT not found!" };
@@ -98506,7 +98505,14 @@ try {
     if (TASK_COMMENT) {
         taskComment = `${TASK_COMMENT} ${PULL_REQUEST.html_url}`;
     }
-    while ((parseAsanaURL = REGEX.exec(PULL_REQUEST.body)) !== null) {
+
+    const foundAsanaURLs = [...(PULL_REQUEST?.body?.matchAll(REGEX) || [])];
+
+    if (foundAsanaURLs.length === 0) {
+        core.debug("0 Asana URLs found matching the `trigger-phrase`.")
+    }
+
+    for (const parseAsanaURL of foundAsanaURLs) {
         let taskId = parseAsanaURL.groups.task;
         if (taskId) {
             core.info(`Handling Asana task ID: ${taskId}`);

--- a/index.js
+++ b/index.js
@@ -73,8 +73,7 @@ try {
     core.info(`Task comment: "${TASK_COMMENT}"`);
     core.info(`Mark complete: "${MARK_COMPLETE}"`);
     core.info(`PR body: ${PULL_REQUEST.body}`);
-    let taskComment = null,
-        parseAsanaURL = null;
+    let taskComment = null
 
     if (!ASANA_PAT) {
         throw { message: "Asana PAT not found!" };
@@ -82,7 +81,14 @@ try {
     if (TASK_COMMENT) {
         taskComment = `${TASK_COMMENT} ${PULL_REQUEST.html_url}`;
     }
-    while ((parseAsanaURL = REGEX.exec(PULL_REQUEST.body)) !== null) {
+
+    const foundAsanaURLs = [...(PULL_REQUEST?.body?.matchAll(REGEX) || [])];
+
+    if (foundAsanaURLs.length === 0) {
+        core.debug("0 Asana URLs found matching the `trigger-phrase`.")
+    }
+
+    for (const parseAsanaURL of foundAsanaURLs) {
         let taskId = parseAsanaURL.groups.task;
         if (taskId) {
             core.info(`Handling Asana task ID: ${taskId}`);


### PR DESCRIPTION
I was confused as to the output I was seeing in the action when I had my `trigger-phrase` configured differently then the way I had it in my PR. I was expecting to get some more information about what the action was doing, but it would just stop after printing the PR body.

This PR gathers all `RegEx` matches at the start and uses that count to check if there were zero matches.