### PR TITLE
feat: use typescript to check JS code

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,3 +29,15 @@ jobs:
       - name: Assert no changes from `yarn build`
         run: git diff --exit-code HEAD --
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+      - name: install yarn and dependencies
+        run: |
+          npm install -g yarn
+          yarn
+      - run: tsc

--- a/dist/index.js
+++ b/dist/index.js
@@ -98426,6 +98426,13 @@ const core = __nccwpck_require__(2186);
 const github = __nccwpck_require__(5438);
 const asana = __nccwpck_require__(3565);
 
+/**
+ * @param {string} asanaPAT The Asana "Personal Access Token" (PAT) used to access the Asana API.
+ * @param {any} taskId The ID of the Asana Task to act on.
+ * @param {string | null} targetSection Optional name of the Asana Board Section to move the {@link taskId Asana Task} to.
+ * @param {string | null} taskComment Optional comment to add to the {@link taskId Asana Task}
+ * @param {boolean} markComplete Whether to mark the {@link taskId Asana Task} as completed.
+ */
 async function asanaOperations(
     asanaPAT,
     targetSection,

--- a/dist/index.js
+++ b/dist/index.js
@@ -98483,7 +98483,14 @@ async function asanaOperations(
             core.info(`Task ${taskId} marked as complete.`);
         }
     } catch (error) {
-        core.setFailed(error.message);
+        if (typeof error === "string") {
+            error = new Error(error);
+        }
+        if (error instanceof Error) {
+            core.setFailed(error.message);
+        } else {
+            core.setFailed(`Unknown error: ${error}`);
+        }
     }
 }
 
@@ -98503,14 +98510,14 @@ try {
     core.info(`Target section: ${TARGET_SECTION}`);
     core.info(`Task comment: "${TASK_COMMENT}"`);
     core.info(`Mark complete: "${MARK_COMPLETE}"`);
-    core.info(`PR body: ${PULL_REQUEST.body}`);
+    core.info(`PR body: ${PULL_REQUEST?.body}`);
     let taskComment = null;
 
     if (!ASANA_PAT) {
         throw { message: "Asana PAT not found!" };
     }
     if (TASK_COMMENT) {
-        taskComment = `${TASK_COMMENT} ${PULL_REQUEST.html_url}`;
+        taskComment = `${TASK_COMMENT} ${PULL_REQUEST?.html_url}`;
     }
 
     const foundAsanaURLs = [...(PULL_REQUEST?.body?.matchAll(REGEX) || [])];
@@ -98520,7 +98527,7 @@ try {
     }
 
     for (const parseAsanaURL of foundAsanaURLs) {
-        let taskId = parseAsanaURL.groups.task;
+        let taskId = parseAsanaURL?.groups?.task;
         if (taskId) {
             core.info(`Handling Asana task ID: ${taskId}`);
             asanaOperations(
@@ -98537,7 +98544,14 @@ try {
         }
     }
 } catch (error) {
-    core.setFailed(error.message);
+    if (typeof error === "string") {
+        error = new Error(error);
+    }
+    if (error instanceof Error) {
+        core.setFailed(error.message);
+    } else {
+        core.setFailed(`Unknown error: ${error}`);
+    }
 }
 
 })();

--- a/index.js
+++ b/index.js
@@ -59,7 +59,14 @@ async function asanaOperations(
             core.info(`Task ${taskId} marked as complete.`);
         }
     } catch (error) {
-        core.setFailed(error.message);
+        if (typeof error === "string") {
+            error = new Error(error);
+        }
+        if (error instanceof Error) {
+            core.setFailed(error.message);
+        } else {
+            core.setFailed(`Unknown error: ${error}`);
+        }
     }
 }
 
@@ -79,14 +86,14 @@ try {
     core.info(`Target section: ${TARGET_SECTION}`);
     core.info(`Task comment: "${TASK_COMMENT}"`);
     core.info(`Mark complete: "${MARK_COMPLETE}"`);
-    core.info(`PR body: ${PULL_REQUEST.body}`);
+    core.info(`PR body: ${PULL_REQUEST?.body}`);
     let taskComment = null;
 
     if (!ASANA_PAT) {
         throw { message: "Asana PAT not found!" };
     }
     if (TASK_COMMENT) {
-        taskComment = `${TASK_COMMENT} ${PULL_REQUEST.html_url}`;
+        taskComment = `${TASK_COMMENT} ${PULL_REQUEST?.html_url}`;
     }
 
     const foundAsanaURLs = [...(PULL_REQUEST?.body?.matchAll(REGEX) || [])];
@@ -96,7 +103,7 @@ try {
     }
 
     for (const parseAsanaURL of foundAsanaURLs) {
-        let taskId = parseAsanaURL.groups.task;
+        let taskId = parseAsanaURL?.groups?.task;
         if (taskId) {
             core.info(`Handling Asana task ID: ${taskId}`);
             asanaOperations(
@@ -113,5 +120,12 @@ try {
         }
     }
 } catch (error) {
-    core.setFailed(error.message);
+    if (typeof error === "string") {
+        error = new Error(error);
+    }
+    if (error instanceof Error) {
+        core.setFailed(error.message);
+    } else {
+        core.setFailed(`Unknown error: ${error}`);
+    }
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,13 @@ const core = require("@actions/core");
 const github = require("@actions/github");
 const asana = require("asana");
 
+/**
+ * @param {string} asanaPAT The Asana "Personal Access Token" (PAT) used to access the Asana API.
+ * @param {any} taskId The ID of the Asana Task to act on.
+ * @param {string | null} targetSection Optional name of the Asana Board Section to move the {@link taskId Asana Task} to.
+ * @param {string | null} taskComment Optional comment to add to the {@link taskId Asana Task}
+ * @param {boolean} markComplete Whether to mark the {@link taskId Asana Task} as completed.
+ */
 async function asanaOperations(
     asanaPAT,
     targetSection,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "asana": "^0.18.6"
     },
     "devDependencies": {
+        "@types/asana": "^0.18.16",
         "@vercel/ncc": "^0.38.1",
         "eslint": "^7.29.0",
         "eslint-plugin-prettier": "^3.4.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,112 @@
+{
+  "files": [
+    "./index.js"
+  ],
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    "allowJs": true,                                     /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "checkJs": true,                                     /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,18 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
+"@types/asana@^0.18.16":
+  version "0.18.16"
+  resolved "https://registry.yarnpkg.com/@types/asana/-/asana-0.18.16.tgz#e3470eb74f25a73135390b116e24453b0839443d"
+  integrity sha512-BaDrmvO8rTfj9ZRzuXP+i0UlAmQkkSgJKxaNmWa4xpQwuQVoBbCJPHF57aKjaRtsdX1YqfdimVTY3zCmnm5+5w==
+  dependencies:
+    "@types/bluebird" "*"
+
+"@types/bluebird@*":
+  version "3.5.42"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.42.tgz#7ec05f1ce9986d920313c1377a5662b1b563d366"
+  integrity sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==
+
 "@vercel/ncc@^0.38.1":
   version "0.38.1"
   resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.38.1.tgz#13f08738111e1d9e8a22fd6141f3590e54d9a60e"


### PR DESCRIPTION
Related: #7

It's possible to use typescript to typecheck JS via JSDoc. This gains the help of typescript but doesn't incur a whole rewrite or file type change to get TS linting, LSP, and type checking.

When I was originally working on #5 I missed adding `const` to the new variable, which `tsc` was able to catch, so I figured this would be a good way to introduce some CI helpers for this project.

## Example of success vs failure
### Failure
- https://github.com/mbta/github-asana-action/actions/runs/8928005368/job/24522596144

### Success
- https://github.com/mbta/github-asana-action/actions/runs/8928025832