### PR TITLE
tweak: modify asana url regex to match new format

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -98502,7 +98502,7 @@ try {
         MARK_COMPLETE = core.getBooleanInput("mark-complete"),
         PULL_REQUEST = github.context.payload.pull_request,
         REGEX = new RegExp(
-            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com\\/(\\d+)\\/(?<project>\\d+)\\/(?<task>\\d+).*?`,
+            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com(\\/.*\\/)+task\\/(?<task>\\d+).*?`,
             "g",
         );
     core.info("Beginning run with:");

--- a/dist/index.js
+++ b/dist/index.js
@@ -98502,7 +98502,7 @@ try {
         MARK_COMPLETE = core.getBooleanInput("mark-complete"),
         PULL_REQUEST = github.context.payload.pull_request,
         REGEX = new RegExp(
-            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com(\\/.*\\/)+task\\/(?<task>\\d+).*?`,
+            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com(\\/1\\/.*\\/task\\/|\\/0\\/.*\\/)(?<task>\\d+).*?`,
             "g",
         );
     core.info("Beginning run with:");

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ try {
         MARK_COMPLETE = core.getBooleanInput("mark-complete"),
         PULL_REQUEST = github.context.payload.pull_request,
         REGEX = new RegExp(
-            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com(\\/.*\\/)+task\\/(?<task>\\d+).*?`,
+            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com(\\/1\\/.*\\/task\\/|\\/0\\/.*\\/)(?<task>\\d+).*?`,
             "g",
         );
     core.info("Beginning run with:");

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ try {
         MARK_COMPLETE = core.getBooleanInput("mark-complete"),
         PULL_REQUEST = github.context.payload.pull_request,
         REGEX = new RegExp(
-            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com\\/(\\d+)\\/(?<project>\\d+)\\/(?<task>\\d+).*?`,
+            `${TRIGGER_PHRASE}(\\s)*(?:\\[.*\\]\\()?https:\\/\\/app.asana.com(\\/.*\\/)+task\\/(?<task>\\d+).*?`,
             "g",
         );
     core.info("Beginning run with:");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "github-asana-action",
-    "version": "v4.5.0",
+    "version": "v4.4.3",
     "description": "Action to integrate GitHub with Asana",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "github-asana-action",
-    "version": "v4.4.2",
+    "version": "v4.5.0",
     "description": "Action to integrate GitHub with Asana",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Update the regex to support the change in Asana task URLs to v1

[Asana still supports v0 links](https://forum.asana.com/t/upcoming-new-v1-asana-url-format-in-the-browser/1011489)

Asana task URLs have changed by default in the browser from a form like:
`https://app.asana.com/0/1185117109217413/1210077353559493`
to
`https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210077353559493`

https://regex101.com/r/WZJWTc/3